### PR TITLE
appdata: Don't repeat application name in summary

### DIFF
--- a/de.klayout.KLayout.metainfo.xml
+++ b/de.klayout.KLayout.metainfo.xml
@@ -3,7 +3,7 @@
   <id>de.klayout.KLayout</id>
   
   <name>KLayout</name>
-  <summary>KLayout, viewer and editor for mask layouts</summary>
+  <summary>Viewer and editor for mask layouts</summary>
   <url type="homepage">https://www.klayout.de</url>
   <url type="bugtracker">https://github.com/KLayout/klayout/issues</url>
   <url type="help">https://www.klayout.de/forum/</url>


### PR DESCRIPTION
This is redundant with the name of the application.

The AppStream spec [says][0]:

> A short summary on what this application does, roughly equivalent to the Comment field of the accompanying .desktop file of the application.

The [desktop entry spec][1] says:

>  Tooltip for the entry, for example "View sites on the Internet". The value should not be redundant with the values of Name and GenericName. 

[0]: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-summary
[1]: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys